### PR TITLE
Create `webhook_deploy` with a path-based `_id`

### DIFF
--- a/src/vercel-deploy.js
+++ b/src/vercel-deploy.js
@@ -88,6 +88,9 @@ export default class Deploy extends React.Component {
   onSubmit = () => {
     client
       .create({
+        // Explicitly define an _id inside the vercel-deploy path to make sure it's not publicly accessible
+        // This will protect users' tokens & project info. Read nmore: https://www.sanity.io/docs/ids
+        _id: `vercel-deploy.${Math.random().toString().replace('.', '')}`,
         _type: WEBHOOK_TYPE,
         name: this.state.pendingWebhookTitle,
         url: this.state.pendingWebhookURL,


### PR DESCRIPTION
Hey Nick 👋 

First of all, congratulations for this beautiful, intuitive plugin. Effortless and extremely practical, it's really helping :D 

I'm a bit concerned about security, though: as we need to add a Vercel token & webhook to our configuration, it'd be ideal if the `webhook_deploy` documents created were private. To do this, all we need to do is add a path before the `_id` of each created document, as path-based `_id`s are private by default ([see docs](https://www.sanity.io/docs/ids#paths-fdc25ada5db2)). This makes no difference in private datasets as all their documents are private by default.

A good reference of a plugin using this technique is the [official Mux Input](https://www.sanity.io/plugins/sanity-plugin-mux-input).

This little PR adds a cheap and dirty way for enabling this. I opted for `Math.random()` as it's the cheapest way to add almost-unique ids, but we could always reach for [nanoid](https://www.npmjs.com/package/nanoid) or similar 😉 

Again, thank you a ton  - no rush to review this 😄