### PR TITLE
Support team deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h3>
 <p align="center">
   <strong>Trigger Vercel Deploy Hooks from your Sanity Studio.</strong><br />
-✨ LIVE status updates ✨ multiple deployments ✨ active polling ✨
+✨ LIVE status updates ✨ multiple deployments ✨ active polling ✨ Vercel Teams support ✨
 </p>
 
 ![vercel-deploy](https://user-images.githubusercontent.com/737188/101732948-047c0080-3a8c-11eb-9c07-777cfe10fa82.gif)
@@ -36,6 +36,10 @@ Next, you'll be prompted to add the following:
 
 > **`Vercel Project Name`**<br />
 > This is the actual Project Name listed in your Vercel account. Navigate to your Project Settings within Vercel to find your Project Name.
+
+> **`Vercel Team Slug`**<br />
+> If your project is part of a Vercel Team you will need to fill out this field. Navigate to your Team from within Vercel, and use the URL slug (ie. vercel.com/`team-666`).
+
 
 > **`Deploy Hook URL`**<br />
 > This is the Vercel Deploy hook you want to trigger. You can set these up within your Vercel Project, under Settings -> Git and scroll down to the "Deploy Hooks" section. Create your desired hook (ie. "Production Deploy" on `master` branch)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-vercel-deploy",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -319,9 +319,9 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -365,9 +365,9 @@
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
-      "integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+      "integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
@@ -644,9 +644,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
-      "integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+      "integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -981,16 +981,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.10.tgz",
-      "integrity": "sha512-Gz9hnBT/tGeTE2DBNDkD7BiWRELZt+8lSysHuDwmYXUIvtwZl0zI+D6mZgXZX0u8YBlLS4tmai9ONNY9tjRgRA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+      "integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.12.7",
         "@babel/helper-compilation-targets": "^7.12.5",
         "@babel/helper-module-imports": "^7.12.5",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-validator-option": "^7.12.1",
+        "@babel/helper-validator-option": "^7.12.11",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-dynamic-import": "^7.12.1",
@@ -1019,7 +1019,7 @@
         "@babel/plugin-transform-arrow-functions": "^7.12.1",
         "@babel/plugin-transform-async-to-generator": "^7.12.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.12.1",
-        "@babel/plugin-transform-block-scoping": "^7.12.1",
+        "@babel/plugin-transform-block-scoping": "^7.12.11",
         "@babel/plugin-transform-classes": "^7.12.1",
         "@babel/plugin-transform-computed-properties": "^7.12.1",
         "@babel/plugin-transform-destructuring": "^7.12.1",
@@ -1049,9 +1049,28 @@
         "@babel/plugin-transform-unicode-escapes": "^7.12.1",
         "@babel/plugin-transform-unicode-regex": "^7.12.1",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.12.10",
+        "@babel/types": "^7.12.11",
         "core-js-compat": "^3.8.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/preset-modules": {
@@ -1377,16 +1396,16 @@
       }
     },
     "browserslist": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
-      "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001164",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.612",
+        "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.67"
+        "node-releases": "^1.1.70"
       }
     },
     "cache-base": {
@@ -1408,19 +1427,19 @@
       }
     },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001165",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-      "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
+      "version": "1.0.30001181",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz",
+      "integrity": "sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ==",
       "dev": true
     },
     "chalk": {
@@ -1631,12 +1650,12 @@
       "optional": true
     },
     "core-js-compat": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.1.tgz",
-      "integrity": "sha512-a16TLmy9NVD1rkjUGbwuyWkiDoN0FDpAwrfLONvHFQx0D9k7J9y0srwMT8QP/Z6HE3MIFaVynEeYwZwPX1o5RQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.3.tgz",
+      "integrity": "sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.15.0",
+        "browserslist": "^4.16.1",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -1727,9 +1746,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.621",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.621.tgz",
-      "integrity": "sha512-FeIuBzArONbAmKmZIsZIFGu/Gc9AVGlVeVbhCq+G2YIl6QkT0TDn2HKN/FMf1btXEB9kEmIuQf3/lBTVAbmFOg==",
+      "version": "1.3.649",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.649.tgz",
+      "integrity": "sha512-ojGDupQ3UMkvPWcTICe4JYe17+o9OLiFMPoduoR72Zp2ILt1mRVeqnxBEd6s/ptekrnsFU+0A4lStfBe/wyG/A==",
       "dev": true
     },
     "escalade": {
@@ -1961,9 +1980,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
+      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -2262,8 +2281,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -2292,6 +2310,14 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "make-dir": {
       "version": "2.1.0",
@@ -2413,9 +2439,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+      "version": "1.1.70",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.70.tgz",
+      "integrity": "sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==",
       "dev": true
     },
     "normalize-path": {
@@ -2424,6 +2450,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -2553,10 +2584,20 @@
       "dev": true,
       "optional": true
     },
-    "react-icons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.1.0.tgz",
-      "integrity": "sha512-FCXBg1JbbR0vWALXIxmFAfozHdVIJmmwCD81Jk0EKOt7Ax4AdBNcaRkWhR0NaKy9ugJgoY3fFvo0PHpte55pXg=="
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-polling": {
       "version": "1.0.9",
@@ -2652,9 +2693,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.7.tgz",
+      "integrity": "sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-plugin-vercel-deploy",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Trigger Vercel Deploy Hooks from your Sanity Studio.",
   "keywords": [
     "sanity",
@@ -18,29 +18,28 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src -d dist --copy-files",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2",
-    "axios": "^0.21.0",
+    "@babel/runtime": "^7.12.5",
+    "axios": "^0.21.1",
     "nanoid": "^3.1.20",
-    "react-icons": "^4.1.0",
-    "react-polling": "^1.0.9"
+    "react-polling": "^1.0.9",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@babel/cli": "^7.6.3",
-    "@babel/core": "^7.6.3",
-    "@babel/plugin-proposal-class-properties": "^7.1.0",
-    "@babel/plugin-transform-runtime": "^7.6.2",
-    "@babel/preset-env": "^7.0.0",
-    "@babel/preset-react": "^7.0.0"
+    "@babel/cli": "^7.12.10",
+    "@babel/core": "^7.12.10",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/plugin-transform-runtime": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/preset-react": "^7.12.10"
   },
   "peerDependencies": {
     "@sanity/base": "^2.1.1",
     "@sanity/components": "^2.1.0",
     "@sanity/dashboard": "^2.1.0",
-    "@sanity/icons": "^1.0.0-beta.4",
+    "@sanity/icons": "^1.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@sanity/components": "^2.1.0",
     "@sanity/dashboard": "^2.1.0",
     "@sanity/icons": "^1.0.0",
+    "@sanity/ui": "^0.33.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },

--- a/src/deploy-item.css
+++ b/src/deploy-item.css
@@ -5,7 +5,7 @@
 .hook {
 	display: flex;
 	align-items: center;
-	padding: 2rem;
+	padding: 1rem;
 }
 
 .hook:not(:first-child) {
@@ -14,13 +14,18 @@
 
 .hookDetails {
 	margin-right: auto;
-	padding-right: 2em;
+	padding: 1rem;
+	overflow: hidden;
 }
 
 .hookTitle {
 	composes: heading5 from 'part:@sanity/base/theme/typography/headings-style';
 	margin-top: 0;
 	padding-top: 0;
+}
+
+.hookTitle [data-ui="Badge"] {
+	vertical-align: top;
 }
 
 .hookURL {
@@ -30,6 +35,8 @@
   font-size: 13px;
   font-family: var(--font-family-monospace);
   white-space: pre-wrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .hookActions {
@@ -37,6 +44,7 @@
 	flex-wrap: nowrap;
 	align-items: center;
 	flex-shrink: 0;
+	padding: 1rem;
 }
 
 .deployButton,
@@ -49,7 +57,15 @@
 	position: relative;
 }
 
+.hookStatusError {
+	margin-left: .5rem;
+	line-height: 0;
+	cursor: pointer;
+}
+
 .hookStatusIndicator {
+	display: flex;
+	align-items: center;
 	margin-right: 1em;
 	padding-left: 1.25em;
 }
@@ -60,7 +76,7 @@
 	position: absolute;
 	left: 0;
 	top: 50%;
-	margin-top: -.3125em;
+	transform: translateY(-50%);
 	width: .625em;
 	height: .625em;
 	border-radius: 50%;

--- a/src/deploy-item.js
+++ b/src/deploy-item.js
@@ -13,7 +13,8 @@ const deployItem = ({
   id,
   vercelProject,
   vercelToken,
-  toggleSnackbar
+  vercelTeamId,
+  toggleSnackbar,
 }) => {
   const [isUpdating, setUpdating] = useState(vercelToken && vercelProject)
   const [isDeploying, setDeploying] = useState(false)
@@ -80,9 +81,11 @@ const deployItem = ({
       method: 'GET',
       headers: {
         'content-type': 'application/json',
-        Authorization: `Bearer ${vercelToken}`
+        Authorization: `Bearer ${vercelToken}`,
       },
-      url: `https://api.vercel.com/v5/now/deployments?projectId=${project}&limit=1`
+      url: `https://api.vercel.com/v5/now/deployments?projectId=${project}&limit=1${
+        vercelTeamId ? `&teamId=${vercelTeamId}` : ''
+      }`,
     }
 
     return axios(options)
@@ -95,7 +98,9 @@ const deployItem = ({
         'content-type': 'application/json',
         Authorization: `Bearer ${vercelToken}`
       },
-      url: `https://api.vercel.com/v1/projects/${id}`
+      url: `https://api.vercel.com/v1/projects/${id}${
+        vercelTeamId ? `?teamId=${vercelTeamId}` : ''
+      }`,
     }
 
     return axios(options)


### PR DESCRIPTION
This PR adds support to team-owned projects in Vercel. This is done through a new "Team slug" field in the "Create new" dialog, which we use to fetch the team's id.

The team's id is what allows us to fetch these projects from Vercel, as [specified in their documentation](https://vercel.com/docs/api#api-basics/authentication/accessing-resources-owned-by-a-team). It's a pretty simple change and I didn't go the extra mile on validation and the likes, but at least we error out when we can't find the team's id.

Future improvements could include a team name's badge in `deploy-item`, links to the project in Vercel, loading states in the "Create new" dialog, etc.

Let me know if you need anything else to have this merged, @ndimatteo 🙌 

PS: I also took the liberty to remove react-icons as a dependency as that wasn't being used and adds a large overhead to the install bundle of this plugin