### PR TITLE
Remove unnecessary peer deps, allow react 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
+        "@sanity/icons": "^1.0.8",
+        "@sanity/ui": "^0.33.24",
         "axios": "^0.21.1",
         "nanoid": "^3.1.20",
         "prop-types": "^15.7.2",
@@ -25,10 +27,6 @@
       },
       "peerDependencies": {
         "@sanity/base": "^2.1.1",
-        "@sanity/components": "^2.1.0",
-        "@sanity/dashboard": "^2.1.0",
-        "@sanity/icons": "^1.0.0",
-        "@sanity/ui": "^0.33.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
       }
@@ -39,8 +37,6 @@
       "integrity": "sha512-cL9tllhqvsQ6r1+d9Invf7nNXg/3BlfL1vvvL/AdH9fZ2l5j0CeBcoq6UjsqHpvyN1v5nXSZgqJZoGeK+ZOAbw==",
       "dev": true,
       "dependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -1426,7 +1422,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
       }
@@ -1434,8 +1429,7 @@
     "node_modules/@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "peer": true
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -1452,8 +1446,7 @@
     "node_modules/@juggle/resize-observer": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==",
-      "peer": true
+      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
@@ -1479,7 +1472,6 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
       "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1618,31 +1610,9 @@
       }
     },
     "node_modules/@sanity/color": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.0.15.tgz",
-      "integrity": "sha512-HN+S2H4wq5ZMJe/TmZPUByF6FqSyedYiDxV2YKWNyH4r/NbRvUlGnDe0caIFV0aVkRW+apLYoiqXDsr23kSrOQ==",
-      "peer": true
-    },
-    "node_modules/@sanity/components": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@sanity/components/-/components-2.2.6.tgz",
-      "integrity": "sha512-KK+6eJgrgHEd9Hq+LbRamdAI64cNXYoVn/f/Dn3ES1GA55AvQyKQUay4T/zZ1yEITKSyIZgETQjpAl/Hg+72eQ==",
-      "peer": true
-    },
-    "node_modules/@sanity/dashboard": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@sanity/dashboard/-/dashboard-2.7.0.tgz",
-      "integrity": "sha512-i5WPUNobXAudttwj3+YbZoXWaHcjazeuUE9aY6xfcdo/FJIrK5am/Vz1DhgWBYrmKYds0kBTM9zR7vNbQdAZIQ==",
-      "peer": true,
-      "dependencies": {
-        "@sanity/image-url": "^0.140.19",
-        "lodash": "^4.17.15",
-        "rxjs": "^6.5.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.6 || ^16",
-        "react": "^16.9 || ^17"
-      }
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.0.17.tgz",
+      "integrity": "sha512-gLh5rhM1+jtPqIyRwYHr4ZT4iyrKGlVMoYeJD6mlcIWPkMppJ+FYzkViwCvByQnQ9Ez/nL9kq2dz1IDXvsHaHg=="
     },
     "node_modules/@sanity/eventsource": {
       "version": "2.2.6",
@@ -1661,10 +1631,9 @@
       "peer": true
     },
     "node_modules/@sanity/icons": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.0.6.tgz",
-      "integrity": "sha512-+7U2ZJPhRuaS1dMDro+3zZ0lSMo9qyHlmtTkCbf4JspYb025W/5YkVRnN63FDwkLZrjLdTrZQI3cPsDwpp2t9A==",
-      "peer": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.0.8.tgz",
+      "integrity": "sha512-uTrShlEGkRa3qhYVsT1cmjM9KoScBFyI3BqE1wwYRNjE90AoJ41ZU2pxjPXdhNo91yWOTAih6x7rgjtFIEp8hw==",
       "peerDependencies": {
         "react": "^16.9 || ^17"
       }
@@ -1808,17 +1777,16 @@
       }
     },
     "node_modules/@sanity/ui": {
-      "version": "0.33.19",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.33.19.tgz",
-      "integrity": "sha512-9zDkEBY/tPwvypX3G0dhFg3AyjrG6CD0lUq/NywmkjsXZ/sKlIl/TpsQvf9miubGlUunc7lmmhDxLO75SpK9Yg==",
-      "peer": true,
+      "version": "0.33.24",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.33.24.tgz",
+      "integrity": "sha512-DlNhIH5AOD9Baiv2R9yAXqid/H3aVOoB/R9/qkD5p7oCDIfn7w/KSVrQWSVeTu6DZMwsHwgTkwWIyetfhZ6uhg==",
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.0",
+        "@juggle/resize-observer": "^3.3.1",
         "@popperjs/core": "^2.9.2",
         "@reach/auto-id": "^0.15.0",
-        "@sanity/color": "^2.0.15",
-        "@sanity/icons": "^1.0.6",
-        "framer-motion": "^4.1.8",
+        "@sanity/color": "^2.0.17",
+        "@sanity/icons": "^1.0.8",
+        "framer-motion": "^4.1.14",
         "popper-max-size-modifier": "^0.2.0",
         "react-is": "^17.0.2",
         "react-popper": "^2.2.5",
@@ -1834,7 +1802,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
       "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
-      "peer": true,
       "dependencies": {
         "@reach/utils": "0.15.0",
         "tslib": "^2.1.0"
@@ -1848,7 +1815,6 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
       "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
-      "peer": true,
       "dependencies": {
         "tiny-warning": "^1.0.3",
         "tslib": "^2.1.0"
@@ -1897,7 +1863,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
       "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -1940,8 +1905,7 @@
     "node_modules/@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-      "peer": true
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -2353,7 +2317,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2363,7 +2326,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
       "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2373,7 +2335,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2388,7 +2349,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2637,7 +2597,6 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
       "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -2696,7 +2655,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
       "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2908,8 +2866,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/dequal": {
       "version": "2.0.2",
@@ -3252,15 +3209,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.11.tgz",
-      "integrity": "sha512-7N67I8PUNH3OT0RTlNB672k5UiuWg5B17c+9Lc6BjICRo66gKeiq/Hy091lWCqNuSLEO59F9z39zxb3wMg6Tjg==",
-      "peer": true,
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.3.5",
+        "popmotion": "9.3.6",
         "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
       },
@@ -3276,7 +3231,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
       "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3497,7 +3451,6 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "delegate": "^3.1.2"
       }
@@ -3585,7 +3538,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
       "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -3595,7 +3547,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -3611,8 +3562,7 @@
     "node_modules/hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "peer": true
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/history": {
       "version": "4.10.1",
@@ -3706,7 +3656,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3716,7 +3665,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "peer": true,
       "dependencies": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -3775,7 +3723,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3831,7 +3778,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3966,9 +3912,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4506,7 +4449,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "peer": true,
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -4599,10 +4541,9 @@
       }
     },
     "node_modules/popmotion": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.5.tgz",
-      "integrity": "sha512-Lr2rq8OP0j8D7CO2/6eO17ALeFCxjx1hfTGbMg+TLqFj+KZSGOoj6gRBVTzDINGqo6LQrORQSSSDaCL5OrB3bw==",
-      "peer": true,
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "dependencies": {
         "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
@@ -4614,7 +4555,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
       "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.2.0"
       }
@@ -4639,10 +4579,6 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "peer": true,
-      "dependencies": {
-        "clipboard": "^2.0.0"
-      },
       "optionalDependencies": {
         "clipboard": "^2.0.0"
       }
@@ -4696,7 +4632,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "peer": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -4761,8 +4696,7 @@
     "node_modules/react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "peer": true
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-icon-base": {
       "version": "2.1.2",
@@ -4777,8 +4711,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "peer": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -4790,7 +4723,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
       "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "peer": true,
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -4814,7 +4746,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-2.1.4.tgz",
       "integrity": "sha512-bjFJ6IxBai2FDIdmypvVUQ74OD37YkF9tYBYMrVKOUvd3eyUosVab6PtwqmnYj5MvUjBd956NHzHyYb1jlZ/hA==",
-      "peer": true,
       "dependencies": {
         "prop-types": "^15.6.1",
         "refractor": "^3.3.0",
@@ -4898,7 +4829,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
       "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
-      "peer": true,
       "dependencies": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
@@ -5167,8 +5097,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -5479,7 +5408,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5652,7 +5580,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
       "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
-      "peer": true,
       "dependencies": {
         "hey-listen": "^1.0.8",
         "tslib": "^2.1.0"
@@ -5739,8 +5666,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/tiny-invariant": {
       "version": "1.1.0",
@@ -5751,8 +5677,7 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "peer": true
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -5848,8 +5773,7 @@
     "node_modules/tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "peer": true
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5932,7 +5856,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-2.0.3.tgz",
       "integrity": "sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==",
-      "peer": true,
       "dependencies": {
         "unist-util-is": "^4.0.0"
       }
@@ -5941,7 +5864,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
       "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -5951,7 +5873,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -6076,7 +5997,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -6091,7 +6011,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -7239,7 +7158,6 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "peer": true,
       "requires": {
         "@emotion/memoize": "0.7.4"
       }
@@ -7247,8 +7165,7 @@
     "@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "peer": true
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -7265,8 +7182,7 @@
     "@juggle/resize-observer": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw==",
-      "peer": true
+      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents",
@@ -7291,8 +7207,7 @@
     "@popperjs/core": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==",
-      "peer": true
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
     },
     "@reach/auto-id": {
       "version": "0.13.2",
@@ -7414,27 +7329,9 @@
       }
     },
     "@sanity/color": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.0.15.tgz",
-      "integrity": "sha512-HN+S2H4wq5ZMJe/TmZPUByF6FqSyedYiDxV2YKWNyH4r/NbRvUlGnDe0caIFV0aVkRW+apLYoiqXDsr23kSrOQ==",
-      "peer": true
-    },
-    "@sanity/components": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@sanity/components/-/components-2.2.6.tgz",
-      "integrity": "sha512-KK+6eJgrgHEd9Hq+LbRamdAI64cNXYoVn/f/Dn3ES1GA55AvQyKQUay4T/zZ1yEITKSyIZgETQjpAl/Hg+72eQ==",
-      "peer": true
-    },
-    "@sanity/dashboard": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@sanity/dashboard/-/dashboard-2.7.0.tgz",
-      "integrity": "sha512-i5WPUNobXAudttwj3+YbZoXWaHcjazeuUE9aY6xfcdo/FJIrK5am/Vz1DhgWBYrmKYds0kBTM9zR7vNbQdAZIQ==",
-      "peer": true,
-      "requires": {
-        "@sanity/image-url": "^0.140.19",
-        "lodash": "^4.17.15",
-        "rxjs": "^6.5.3"
-      }
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@sanity/color/-/color-2.0.17.tgz",
+      "integrity": "sha512-gLh5rhM1+jtPqIyRwYHr4ZT4iyrKGlVMoYeJD6mlcIWPkMppJ+FYzkViwCvByQnQ9Ez/nL9kq2dz1IDXvsHaHg=="
     },
     "@sanity/eventsource": {
       "version": "2.2.6",
@@ -7453,10 +7350,9 @@
       "peer": true
     },
     "@sanity/icons": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.0.6.tgz",
-      "integrity": "sha512-+7U2ZJPhRuaS1dMDro+3zZ0lSMo9qyHlmtTkCbf4JspYb025W/5YkVRnN63FDwkLZrjLdTrZQI3cPsDwpp2t9A==",
-      "peer": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.0.8.tgz",
+      "integrity": "sha512-uTrShlEGkRa3qhYVsT1cmjM9KoScBFyI3BqE1wwYRNjE90AoJ41ZU2pxjPXdhNo91yWOTAih6x7rgjtFIEp8hw==",
       "requires": {}
     },
     "@sanity/image-url": {
@@ -7581,17 +7477,16 @@
       }
     },
     "@sanity/ui": {
-      "version": "0.33.19",
-      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.33.19.tgz",
-      "integrity": "sha512-9zDkEBY/tPwvypX3G0dhFg3AyjrG6CD0lUq/NywmkjsXZ/sKlIl/TpsQvf9miubGlUunc7lmmhDxLO75SpK9Yg==",
-      "peer": true,
+      "version": "0.33.24",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-0.33.24.tgz",
+      "integrity": "sha512-DlNhIH5AOD9Baiv2R9yAXqid/H3aVOoB/R9/qkD5p7oCDIfn7w/KSVrQWSVeTu6DZMwsHwgTkwWIyetfhZ6uhg==",
       "requires": {
-        "@juggle/resize-observer": "^3.3.0",
+        "@juggle/resize-observer": "^3.3.1",
         "@popperjs/core": "^2.9.2",
         "@reach/auto-id": "^0.15.0",
-        "@sanity/color": "^2.0.15",
-        "@sanity/icons": "^1.0.6",
-        "framer-motion": "^4.1.8",
+        "@sanity/color": "^2.0.17",
+        "@sanity/icons": "^1.0.8",
+        "framer-motion": "^4.1.14",
         "popper-max-size-modifier": "^0.2.0",
         "react-is": "^17.0.2",
         "react-popper": "^2.2.5",
@@ -7602,7 +7497,6 @@
           "version": "0.15.0",
           "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.15.0.tgz",
           "integrity": "sha512-iACaCcZeqAhDf4OOwJpmHHS/LaRj9z3Ip8JmlhpCrFWV2YOIiiZk42amlBZX6CKH66Md+eriYZQk3TyAjk6Oxg==",
-          "peer": true,
           "requires": {
             "@reach/utils": "0.15.0",
             "tslib": "^2.1.0"
@@ -7612,7 +7506,6 @@
           "version": "0.15.0",
           "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.0.tgz",
           "integrity": "sha512-JHHN7T5ucFiuQbqkgv8ECbRWKfRiJxrO/xHR3fHf+f2C7mVs/KkJHhYtovS1iEapR4silygX9PY0+QUmHPOTYw==",
-          "peer": true,
           "requires": {
             "tiny-warning": "^1.0.3",
             "tslib": "^2.1.0"
@@ -7656,7 +7549,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
       "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
-      "peer": true,
       "requires": {
         "@types/unist": "*"
       }
@@ -7699,8 +7591,7 @@
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-      "peer": true
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -8035,20 +7926,17 @@
     "character-entities": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-      "peer": true
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-legacy": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-      "peer": true
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-      "peer": true
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chokidar": {
       "version": "3.5.1",
@@ -8259,7 +8147,6 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
       "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
       "optional": true,
-      "peer": true,
       "requires": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -8311,8 +8198,7 @@
     "comma-separated-tokens": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
-      "peer": true
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "4.1.1",
@@ -8473,8 +8359,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "dequal": {
       "version": "2.0.2",
@@ -8748,15 +8633,14 @@
       }
     },
     "framer-motion": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.11.tgz",
-      "integrity": "sha512-7N67I8PUNH3OT0RTlNB672k5UiuWg5B17c+9Lc6BjICRo66gKeiq/Hy091lWCqNuSLEO59F9z39zxb3wMg6Tjg==",
-      "peer": true,
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+      "integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.3.5",
+        "popmotion": "9.3.6",
         "style-value-types": "4.1.4",
         "tslib": "^2.1.0"
       }
@@ -8765,7 +8649,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
       "integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
-      "peer": true,
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -8956,7 +8839,6 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
-      "peer": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -9024,14 +8906,12 @@
     "hast-util-parse-selector": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
-      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
-      "peer": true
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hastscript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
       "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
-      "peer": true,
       "requires": {
         "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
@@ -9043,8 +8923,7 @@
     "hey-listen": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "peer": true
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "history": {
       "version": "4.10.1",
@@ -9125,14 +9004,12 @@
     "is-alphabetical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-      "peer": true
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
       "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "peer": true,
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
@@ -9177,8 +9054,7 @@
     "is-decimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-      "peer": true
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -9217,8 +9093,7 @@
     "is-hexadecimal": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-      "peer": true
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -9750,7 +9625,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "peer": true,
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -9821,10 +9695,9 @@
       }
     },
     "popmotion": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.5.tgz",
-      "integrity": "sha512-Lr2rq8OP0j8D7CO2/6eO17ALeFCxjx1hfTGbMg+TLqFj+KZSGOoj6gRBVTzDINGqo6LQrORQSSSDaCL5OrB3bw==",
-      "peer": true,
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+      "integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
       "requires": {
         "framesync": "5.3.0",
         "hey-listen": "^1.0.8",
@@ -9836,7 +9709,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
       "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "peer": true,
       "requires": {}
     },
     "posix-character-classes": {
@@ -9856,7 +9728,6 @@
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
       "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "peer": true,
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -9909,7 +9780,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
       "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-      "peer": true,
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -9964,8 +9834,7 @@
     "react-fast-compare": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
-      "peer": true
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-icon-base": {
       "version": "2.1.2",
@@ -9977,8 +9846,7 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "peer": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -9990,7 +9858,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
       "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
-      "peer": true,
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -10007,7 +9874,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/react-refractor/-/react-refractor-2.1.4.tgz",
       "integrity": "sha512-bjFJ6IxBai2FDIdmypvVUQ74OD37YkF9tYBYMrVKOUvd3eyUosVab6PtwqmnYj5MvUjBd956NHzHyYb1jlZ/hA==",
-      "peer": true,
       "requires": {
         "prop-types": "^15.6.1",
         "refractor": "^3.3.0",
@@ -10022,8 +9888,7 @@
       "peer": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
+        "invariant": "^2.2.4"
       }
     },
     "react-split-pane": {
@@ -10076,7 +9941,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.1.tgz",
       "integrity": "sha512-vaN6R56kLMuBszHSWlwTpcZ8KTMG6aUCok4GrxYDT20UIOXxOc5o6oDc8tNTzSlH3m2sI+Eu9Jo2kVdDcUTWYw==",
-      "peer": true,
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
@@ -10305,8 +10169,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "semver": {
       "version": "6.3.0",
@@ -10560,8 +10423,7 @@
     "space-separated-tokens": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
-      "peer": true
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spacetime": {
       "version": "6.16.0",
@@ -10705,7 +10567,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
       "integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
-      "peer": true,
       "requires": {
         "hey-listen": "^1.0.8",
         "tslib": "^2.1.0"
@@ -10778,8 +10639,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",
@@ -10790,8 +10650,7 @@
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "peer": true
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -10870,8 +10729,7 @@
     "tslib": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-      "peer": true
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -10933,7 +10791,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-filter/-/unist-util-filter-2.0.3.tgz",
       "integrity": "sha512-8k6Jl/KLFqIRTHydJlHh6+uFgqYHq66pV75pZgr1JwfyFSjbWb12yfb0yitW/0TbHXjr9U4G9BQpOvMANB+ExA==",
-      "peer": true,
       "requires": {
         "unist-util-is": "^4.0.0"
       }
@@ -10941,14 +10798,12 @@
     "unist-util-is": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-      "peer": true
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
     },
     "unist-util-visit-parents": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
       "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
-      "peer": true,
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -11050,7 +10905,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -11064,8 +10918,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "peer": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@sanity/icons": "^1.0.8",
+    "@sanity/ui": "^0.33.24",
     "axios": "^0.21.1",
     "nanoid": "^3.1.20",
     "prop-types": "^15.7.2",
@@ -38,12 +40,8 @@
   },
   "peerDependencies": {
     "@sanity/base": "^2.1.1",
-    "@sanity/components": "^2.1.0",
-    "@sanity/dashboard": "^2.1.0",
-    "@sanity/icons": "^1.0.0",
-    "@sanity/ui": "^0.33.0",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": "^16.14.0 || ^17.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0"
   },
   "sanityTemplate": {
     "suggestedName": "vercel-deploy",


### PR DESCRIPTION
- Moves `@sanity/ui` and `@sanity/icons` to regular dependencies (they are not installed in a studio directly, so shouldn't be relied on being there)
- Removes unnecessary peer dependencies (only `@sanity/base` is required for this plugin as it is a tool, as far as I can tell)
- Allows react 17 to be used as peer dependency. Silences warnings/errors when using React 17 with the sanity studio.
