### PR TITLE
Strip query params from url

### DIFF
--- a/src/deploy-history.tsx
+++ b/src/deploy-history.tsx
@@ -41,7 +41,7 @@ const DeployHistory: React.FC<DeployHistoryProps> = ({
       .get(
         `https://api.vercel.com/v5/now/deployments?projectId=${vercelProject}&meta-deployHookId=${url
           .split('/')
-          .pop()}&limit=6${vercelTeam?.id ? `&teamId=${vercelTeam?.id}` : ''}`,
+          .pop().split('?').shift()}&limit=6${vercelTeam?.id ? `&teamId=${vercelTeam?.id}` : ''}`,
         {
           headers: {
             'content-type': 'application/json',

--- a/src/deploy-item.tsx
+++ b/src/deploy-item.tsx
@@ -105,7 +105,7 @@ const DeployItem: React.FC<DeployItemProps> = ({
     () => [
       `https://api.vercel.com/v5/now/deployments?projectId=${
         projectData.id
-      }&meta-deployHookId=${url.split('/').pop()}&limit=1${
+      }&meta-deployHookId=${url.split('/').pop().split('?').shift()}&limit=1${
         vercelTeam?.id ? `&teamId=${vercelTeam?.id}` : ''
       }`,
       vercelToken,


### PR DESCRIPTION
This fixes an [issue](https://github.com/ndimatteo/sanity-plugin-vercel-deploy/issues/38) with errant `meta-deployHookId` values when a query param is present in the url, as is necessary to control [build cache](https://vercel.com/docs/concepts/deployments/deploy-hooks#build-cache)