### PR TITLE
Update Team Name instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ _Typically, this should be the environment you are deploying to, like `Productio
 This is the slugified project name listed in your Vercel account. <br />
 _You can find this in your Vercel Project under Settings → General → "Project Name"_
 
-#### `Vercel Team Name` _(optional)_
+#### `Vercel Team URL` _(optional)_
 
 If your project is part of a Vercel Team you must provide this value. <br />
-_You can find this in your Vercel Team, under Settings → General → "Team Name"_
+_You can find this in your Vercel Team, under Settings → General → "Team URL"_
 
 #### `Deploy Hook URL`
 

--- a/src/deploy-item.tsx
+++ b/src/deploy-item.tsx
@@ -554,8 +554,8 @@ const DeployItem: React.FC<DeployItemProps> = ({
               </FormField>
 
               <FormField
-                title="Vercel Team Name"
-                description={`Required for projects under a Vercel Team: Settings → General → "Team Name"`}
+                title="Vercel Team URL"
+                description={`Required for projects under a Vercel Team: Settings → General → "Team URL"`}
               >
                 <TextInput
                   type="text"

--- a/src/vercel-deploy.tsx
+++ b/src/vercel-deploy.tsx
@@ -433,8 +433,8 @@ const VercelDeploy = () => {
                 </FormField>
 
                 <FormField
-                  title="Vercel Team Name"
-                  description={`Required for projects under a Vercel Team: Settings → General → "Team Name"`}
+                  title="Vercel Team URL"
+                  description={`Required for projects under a Vercel Team: Settings → General → "Team URL"`}
                 >
                   <TextInput
                     type="text"


### PR DESCRIPTION
Vercel API expects Team ID (shown in Team URL field), not Team Name.